### PR TITLE
Add xml syntax highlighting to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ sandbox.eval("while (true) { }");
 
 Just add the following dependency to your projects.
 
-```
+```xml
 <dependency>
     <groupId>org.javadelight</groupId>
     <artifactId>delight-rhino-sandbox</artifactId>


### PR DESCRIPTION
Also missing highlighting:
* https://github.com/javadelight/delight-metrics
* https://github.com/javadelight/delight-graaljs-sandbox
If you would like, I can open pull requests on those projects as well