### PR TITLE
#17 Fixed ClassShutter Issue: Setting class shutter only works once

### DIFF
--- a/src/main/java/delight/rhinosandox/internal/RhinoSandboxImpl.java
+++ b/src/main/java/delight/rhinosandox/internal/RhinoSandboxImpl.java
@@ -76,6 +76,7 @@ public class RhinoSandboxImpl implements RhinoSandbox {
 
     public void assertSafeScope(final Context context) {
         if ((this.safeScope != null)) {
+            context.setClassShutter(this.classShutter);
             return;
         }
         if (this.useSafeStandardObjects) {

--- a/src/main/java/delight/rhinosandox/internal/SafeContext.java
+++ b/src/main/java/delight/rhinosandox/internal/SafeContext.java
@@ -27,11 +27,16 @@ public class SafeContext extends ContextFactory {
   
   public int maxInstructions;
   
+  public SafeClassShutter classShutter;
+  
   @Override
   public Context makeContext() {
     final SafeContext.CountContext cx = new SafeContext.CountContext();
     cx.setOptimizationLevel((-1));
     cx.setInstructionObserverThreshold(SafeContext.INSTRUCTION_STEPS);
+    if (classShutter != null) {
+      cx.setClassShutter(classShutter);
+    }
     return cx;
   }
   

--- a/src/test/java/delight/rhinosandox/tests/TestClassShutter.java
+++ b/src/test/java/delight/rhinosandox/tests/TestClassShutter.java
@@ -1,0 +1,38 @@
+package delight.rhinosandox.tests;
+
+import static org.junit.Assert.assertThrows;
+
+import delight.rhinosandox.RhinoSandbox;
+import delight.rhinosandox.RhinoSandboxes;
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+import org.mozilla.javascript.EcmaError;
+
+public class TestClassShutter {
+    @Test
+    public void javaTestFails() {
+        final RhinoSandbox rhinoSandbox = RhinoSandboxes.create();
+        String jsCode1 = "(function a() {var obj = {x:34,y:100}; return obj;})()";
+        rhinoSandbox.eval(null, jsCode1);
+
+        assertThrows(EcmaError.class, new ThrowingRunnable() {
+            @Override
+            public void run() throws Throwable {
+                String jsCode2 = "(function b() {java.lang.System.out.println('hello');})()";
+                rhinoSandbox.eval(null, jsCode2);
+            }
+        });
+    }
+
+    @Test
+    public void javaTestPasses() {
+        final RhinoSandbox rhinoSandbox = RhinoSandboxes.create();
+        assertThrows(EcmaError.class, new ThrowingRunnable() {
+            @Override
+            public void run() throws Throwable {
+                String jsCode2 = "(function b() {java.lang.System.out.println('hello');})()";
+                System.out.println(rhinoSandbox.eval(null, jsCode2));
+            }
+        });
+    }
+}


### PR DESCRIPTION
* When the RhinoSandboxImpl.assertSafeScope(Context context) is called for the first time, we create this.safeScope and also set the classShutter on the context.
* But for the subsequent runs, since this.safeScope is not null, the code path does not reach the line to set the classShutter
