### PR TITLE
Bump org.eclipse.xtend.lib to 2.25.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.eclipse.xtend</groupId>
 			<artifactId>org.eclipse.xtend.lib</artifactId>
-			<version>2.17.0</version>
+			<version>2.25.0</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Version 2.17 depends upon guava 21.0 which has an open security vulnerability: https://cve.mitre.org/cgi-bin/cvename.cgi?name=2018-10237