### PR TITLE
Add failing unit tests for useSafeStandardObjects bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ See [#31](https://github.com/javadelight/delight-rhino-sandbox/issues/31).
 
 ## Versions
 
+- 0.2.4: Fixing useSafeStandardObjects bypass where ClassShutter and SafeWrapFactory were not installed, allowing unrestricted Java class access [#33](https://github.com/javadelight/delight-rhino-sandbox/issues/33)
 - 0.2.3: Adding wall-clock watchdog and lowering instruction observer threshold to enforce max duration regardless of bytecode count [#31](https://github.com/javadelight/delight-rhino-sandbox/issues/31)
 - 0.2.0: Requiring Java 1.8, allowing to provide scritable parameter for [#27](https://github.com/javadelight/delight-rhino-sandbox/issues/27)
 - 0.1.18: [Migrating Maven Namespace to Central Portal](https://maxrohde.com/2025/05/08/migrating-maven-namespace-to-central-portal/)

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<groupId>org.javadelight</groupId>
 	<artifactId>delight-rhino-sandbox</artifactId>
-	<version>0.2.3</version>
+	<version>0.2.4-SNAPSHOT</version>
 	<description>A safe sandbox for running JavaScript using the Rhino Engine in Java.</description>
 	<url>https://github.com/javadelight/delight-rhino-sandbox</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 			<plugin>
 				<groupId>org.sonatype.central</groupId>
 				<artifactId>central-publishing-maven-plugin</artifactId>
-				<version>0.7.0</version>
+				<version>0.11.0</version>
 				<extensions>true</extensions>
 				<configuration>
 					<publishingServerId>central</publishingServerId>

--- a/src/main/java/delight/rhinosandox/internal/RhinoSandboxImpl.java
+++ b/src/main/java/delight/rhinosandox/internal/RhinoSandboxImpl.java
@@ -89,17 +89,15 @@ public class RhinoSandboxImpl implements RhinoSandbox {
     }
 
     public void assertSafeScope(final Context context) {
+        context.setClassShutter(this.classShutter);
+        context.setWrapFactory(new SafeWrapFactory());
         if ((this.safeScope != null)) {
-            context.setClassShutter(this.classShutter);
             return;
         }
         if (this.useSafeStandardObjects) {
             this.safeScope = context.initSafeStandardObjects(this.globalScope, true);
             return;
         }
-        context.setClassShutter(this.classShutter);
-        SafeWrapFactory _safeWrapFactory = new SafeWrapFactory();
-        context.setWrapFactory(_safeWrapFactory);
         this.safeScope = this.globalScope;
     }
 

--- a/src/test/java/delight/rhinosandox/tests/TestUseSafeStandardObjectsBypass.java
+++ b/src/test/java/delight/rhinosandox/tests/TestUseSafeStandardObjectsBypass.java
@@ -1,0 +1,42 @@
+package delight.rhinosandox.tests;
+
+import static org.junit.Assert.assertThrows;
+
+import delight.rhinosandox.RhinoSandbox;
+import delight.rhinosandox.RhinoSandboxes;
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+import org.mozilla.javascript.EcmaError;
+
+@SuppressWarnings("all")
+public class TestUseSafeStandardObjectsBypass {
+
+    @Test
+    public void test_classShutter_not_applied_with_safeStandardObjects() {
+        final RhinoSandbox sandbox = RhinoSandboxes.create();
+        sandbox.setUseSafeStandardObjects(true);
+
+        assertThrows(EcmaError.class, new ThrowingRunnable() {
+            @Override
+            public void run() throws Throwable {
+                sandbox.eval(null,
+                    "(function b() {java.lang.System.out.println('hello');})()");
+            }
+        });
+    }
+
+    @Test
+    public void test_safeWrapFactory_not_applied_with_safeStandardObjects() {
+        final RhinoSandbox sandbox = RhinoSandboxes.create();
+        sandbox.setUseSafeStandardObjects(true);
+        sandbox.inject("myObj", new Object());
+
+        assertThrows(EcmaError.class, new ThrowingRunnable() {
+            @Override
+            public void run() throws Throwable {
+                sandbox.eval(null,
+                    "(function() { return myObj.getClass(); })()");
+            }
+        });
+    }
+}

--- a/src/test/java/delight/rhinosandox/tests/TestUseSafeStandardObjectsBypass.java
+++ b/src/test/java/delight/rhinosandox/tests/TestUseSafeStandardObjectsBypass.java
@@ -7,6 +7,7 @@ import delight.rhinosandox.RhinoSandboxes;
 import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
 import org.mozilla.javascript.EcmaError;
+import org.mozilla.javascript.EvaluatorException;
 
 @SuppressWarnings("all")
 public class TestUseSafeStandardObjectsBypass {
@@ -31,7 +32,7 @@ public class TestUseSafeStandardObjectsBypass {
         sandbox.setUseSafeStandardObjects(true);
         sandbox.inject("myObj", new Object());
 
-        assertThrows(EcmaError.class, new ThrowingRunnable() {
+        assertThrows(EvaluatorException.class, new ThrowingRunnable() {
             @Override
             public void run() throws Throwable {
                 sandbox.eval(null,


### PR DESCRIPTION
## Summary

Fixes an issue where `setUseSafeStandardObjects(true)` caused `assertSafeScope()` to take an early-return path that skipped both `ClassShutter` and `SafeWrapFactory` installation. This left the sandbox with **unrestricted access to all Java classes** on the classpath.

## Root Cause

In `RhinoSandboxImpl.assertSafeScope()`, `useSafeStandardObjects` and `ClassShutter`/`SafeWrapFactory` were treated as mutually exclusive paths via an early return:

```java
if (this.useSafeStandardObjects) {
    this.safeScope = context.initSafeStandardObjects(this.globalScope, true);
    return;  // <-- ClassShutter and SafeWrapFactory NEVER installed
}
```

## Fix

Moved `ClassShutter` and `SafeWrapFactory` installation to run first in `assertSafeScope()`, before the scope initialization branches. Both protections are now active regardless of which scope path is taken.

These three mechanisms protect different attack surfaces and are complementary, not mutually exclusive:
- `initSafeStandardObjects` — restricts the JavaScript global scope (removes `Packages`, `java`, etc.)
- `ClassShutter` — whitelists which Java classes JS can access by name
- `SafeWrapFactory` — blocks `.getClass()` reflection bypass on wrapped Java objects

## Tests

`TestUseSafeStandardObjectsBypass.java` with two test cases (both pass with the fix):

1. **`test_classShutter_not_applied_with_safeStandardObjects`** — asserts `EcmaError` when accessing `java.lang.System`
2. **`test_safeWrapFactory_not_applied_with_safeStandardObjects`** — asserts `EvaluatorException` when calling `.getClass()` on injected objects

Fixes #33